### PR TITLE
Fix lint errors and React warnings

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 PUBLIC_PATH_URL=http://localhost:8080/
-CP_ADMIN_HOST=http://localhost:15100/
-CP_ADMIN_API=https://localhost:9999/api/v1/
+CP_ADMIN_HOST=http://localhost:15000/
+CP_ADMIN_API=http://localhost:15100/api/v1/
 CP_ANALYTICS_BACKEND=http://localhost:15800/api/v1/
 
 # Tableau

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 PUBLIC_PATH_URL=http://localhost:8888/
 CP_ADMIN_HOST=http://test.com/
-CP_ADMIN_API=https://localhost:9999/api/v1/
+CP_ADMIN_API=http://localhost:9999/api/v1/
 CP_ANALYTICS_BACKEND=http://test.com/analytics/backend/
 
 # Tableau

--- a/app/js/app.jsx
+++ b/app/js/app.jsx
@@ -54,7 +54,7 @@ const App = ({ children, params }) => (
       <Header />
       <LeftHandNavContainer selectedItem={params.id} />
       <FeedbackifyContainer />
-      {props.children}
+      {children}
     </div>
   </MuiThemeProvider>
 )

--- a/app/js/components/feedbackify/feedbackify.jsx
+++ b/app/js/components/feedbackify/feedbackify.jsx
@@ -1,3 +1,4 @@
+/* global fby */ // The fby value comes from the Feedbackify 3rd party library
 import React, { PropTypes } from 'react'
 import './feedbackify.scss'
 
@@ -9,5 +10,9 @@ const setFeedbackifyValues = (email) => () => {
 const Feedbackify = ({email}) => (
   <div className="feedbackify" onClick={setFeedbackifyValues(email)}>feedback</div>
 )
+
+Feedbackify.propTypes = {
+  email: PropTypes.string.isRequired,
+}
 
 export default Feedbackify

--- a/app/js/components/left_hand_nav/left_hand_nav.jsx
+++ b/app/js/components/left_hand_nav/left_hand_nav.jsx
@@ -54,7 +54,7 @@ LeftHandNav.propTypes = {
   leftHandNavVisible: PropTypes.bool.isRequired,
   dashboards: PropTypes.array.isRequired,
   selectDashboard: PropTypes.func.isRequired,
-  selectedDashboardId: PropTypes.string.isRequired,
+  selectedDashboardId: PropTypes.string,
 }
 
 export default LeftHandNav

--- a/app/js/containers/feedbackify_container.js
+++ b/app/js/containers/feedbackify_container.js
@@ -1,8 +1,17 @@
+import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
 import Feedbackify from '../components/feedbackify/feedbackify'
 
-const mapStateToProps = ({analyticsApp}) => ({ email: analyticsApp.profile ? analyticsApp.profile.email : null })
+const FeedbackifyContainer = ({ email }) => email ? <Feedbackify email={email} /> : null
+
+FeedbackifyContainer.propTypes = {
+  email: PropTypes.string,
+}
+
+const mapStateToProps = ({analyticsApp}) => ({
+  email: analyticsApp.profile ? analyticsApp.profile.email : null,
+})
 
 export default connect(
   mapStateToProps
-)(Feedbackify)
+)(FeedbackifyContainer)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3321,9 +3321,9 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "material-ui": {
-      "version": "0.15.2",
-      "from": "material-ui@>=0.15.1 <0.16.0",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.15.2.tgz"
+      "version": "0.15.3",
+      "from": "material-ui@0.15.3",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.15.3.tgz"
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.12.0",
     "client_portal-assets": "github:reevoo/client_portal-assets#v0.3.0",
     "js-cookie": "^2.1.2",
-    "material-ui": "^0.15.1",
+    "material-ui": "^0.15.3",
     "react": "^15.2.0",
     "react-dom": "^15.2.0",
     "react-redux": "^4.4.5",

--- a/tests/unit/app/services/auth.test.js
+++ b/tests/unit/app/services/auth.test.js
@@ -3,7 +3,7 @@ import Auth from 'app/js/services/auth.js'
 import Cookies from 'js-cookie'
 import { Promise } from 'es6-promise'
 
-const CP_API_URL = 'https://localhost:9999/api/v1/'
+const CP_API_URL = 'http://localhost:9999/api/v1/'
 
 describe('Auth', () => {
   beforeEach(() => {


### PR DESCRIPTION
This PR solves a couple of problems with the linter, warnings and tests.

- Changed .env CP_ADMIN_API url to use http instead of https.
- Fixed .env.development values to match the dependent apps ports
- Feedbackify button just renders if an email is provided (this is controlled by the container).
- Fixed wrong prop in app.jsx. Removed required prop in LHN.
- Updated Material-UI to remove lots of React warnings.