### PR TITLE
PROD-2729 Dashboards not loading

### DIFF
--- a/app/js/actions/dashboards.js
+++ b/app/js/actions/dashboards.js
@@ -15,10 +15,13 @@ export const getDashboardToken = () => (dispatch) => {
 export const loadDashboards = (dashboardIds) => (dispatch, getState) => {
   dispatch({ type: actionTypes.GET_DASHBOARDS_NAMES })
   return getWorkbooks(dashboardIds)
-    .then((dashboards) => {
+    .then((responseDashboards) => {
+      // The API might return null values inside the array, so we need to filter them
+      const dashboards = responseDashboards.filter((dashboard) => !!dashboard)
+
       dispatch({ type: actionTypes.GET_DASHBOARDS_NAMES_SUCCESS, payload: dashboards })
       // We need to change the url in the initial load if there is none in the current url
-      if (!getState().router.params.id) {
+      if (dashboards.length > 0 && !getState().router.params.id) {
         dispatch(push({ pathname: `/dashboards/${dashboards[0].id}` }))
       }
     })

--- a/tests/unit/app/actions/dashboards.test.js
+++ b/tests/unit/app/actions/dashboards.test.js
@@ -61,6 +61,25 @@ describe('actions', () => {
         })
     })
 
+    it('executes the async flow with a successful ajax request and null values on the response', (done) => {
+      fetchMock.get(
+        `${TABLEAU_GATEWAY_API}workbooks?ids[]=dashboard_1&ids[]=dashboard_2&ids[]=dashboard_3`,
+        ['dashboard_1', null, 'dashboard_3']
+      )
+
+      const expectedActions = [
+        {type: actionTypes.GET_DASHBOARDS_NAMES},
+        {type: actionTypes.GET_DASHBOARDS_NAMES_SUCCESS, payload: ['dashboard_1', 'dashboard_3']},
+      ]
+      const store = createMockStore({router: {params: {id: '1'}}})
+
+      store.dispatch(loadDashboards(['dashboard_1', 'dashboard_2', 'dashboard_3']))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions)
+          done()
+        })
+    })
+
     it('executes the async flow with a failing ajax request', (done) => {
       fetchMock.get(
         `${TABLEAU_GATEWAY_API}workbooks?ids[]=dashboard_1&ids[]=dashboard_2`,


### PR DESCRIPTION
[JIRA Ticket PROD-2729](https://reevoo.atlassian.net/browse/PROD-2729)

The Dashboards for some clients weren't loading. The response array that we receive from the API might contain elements whose value is `null`. This just filters them, so the valid elements can be rendered. 