### PR TITLE
Hide dashboard title

### DIFF
--- a/app/js/components/dashboard_panel/dashboard_panel.jsx
+++ b/app/js/components/dashboard_panel/dashboard_panel.jsx
@@ -15,9 +15,9 @@ const cardHeaderTitleStyles = {
 const DashboardPanel = ({ leftHandNavVisible, title }) => {
   return (
     <div className={`dashboard-panel ${leftHandNavVisible ? 'collapsed' : 'expanded'}`}>
-      <Card style={cardHeaderStyles} className='dashboard-panel__header'>
+      {title ? <Card style={cardHeaderStyles} className='dashboard-panel__header'>
         <CardHeader title={title} titleStyle={cardHeaderTitleStyles} />
-      </Card>
+      </Card> : null}
       <DashboardFiltersContainer />
       <div id="dashboard-container" />
     </div>

--- a/app/js/containers/dashboard_panel_container.js
+++ b/app/js/containers/dashboard_panel_container.js
@@ -16,8 +16,10 @@ class DashboardPanelContainer extends Component {
 
   render () {
     const { leftHandNavVisible, selectedDashboard } = this.props
-    const title = selectedDashboard ? selectedDashboard.name : 'Loading dashboard...'
-
+    let title = selectedDashboard ? selectedDashboard.name : 'Loading dashboard...'
+    // TODO: This is a temporary solution to hide the dashboard title
+    // until we have all the dashboards with the proper setup on Tableau
+    if (title !== 'Customer_Experience_JavaScipt') { title = null }
     return <DashboardPanel title={title} leftHandNavVisible={leftHandNavVisible} />
   }
 }


### PR DESCRIPTION
Currently only the Customer_Experience dashboard has the right setup in tableau and the title bar should only be displayed for this dashboard. When all the dashboards will have the right setup and the title will be removed from the iframe then this line can be removed