### PR TITLE
Tool 343 analytics trkref filters

### DIFF
--- a/app/js/actions/dashboards.js
+++ b/app/js/actions/dashboards.js
@@ -82,7 +82,7 @@ export const changeFilter = (filterName, filterValue) => (dispatch, getState) =>
   const filter = state.analyticsApp.workbook.filters.find((f) => f.name === filterName)
 
   if (filter) {
-    return setFilterValue(getCurrentWorkbook(state), filter, filterValue).then(() => dispatch({
+    return setFilterValue(getCurrentWorkbook(state), filter, filterValue).always(() => dispatch({
       type: actionTypes.SET_DASHBOARD_FILTER,
       payload: { name: filterName, value: filterValue },
     }))

--- a/app/js/actions/dashboards.js
+++ b/app/js/actions/dashboards.js
@@ -40,7 +40,7 @@ export const getProfileAndDashboards = () => (dispatch, getState) => {
 /**
  * Loads the Tableau Dashboard identified by the @id param in the url
  */
-export const loadTableauDashboard = () => (dispatch, getState) => {
+export const loadTableauDashboard = (availableTrkrefs) => (dispatch, getState) => {
   dispatch({ type: actionTypes.GET_DASHBOARD_TOKEN })
 
   return getTableauToken().then(({ token }) => {
@@ -54,6 +54,7 @@ export const loadTableauDashboard = () => (dispatch, getState) => {
 
     const tableauAPI = createTableauAPI({
       userId: profile.id,
+      availableTrkrefs,
       token,
       viewId: getSelectedDashboardById(dashboards, router.params.id).views[0].replace('sheets/', ''),
       onLoad: ([appFilters, views]) => {

--- a/app/js/actions/dashboards.js
+++ b/app/js/actions/dashboards.js
@@ -82,10 +82,11 @@ export const changeFilter = (filterName, filterValue) => (dispatch, getState) =>
   const filter = state.analyticsApp.workbook.filters.find((f) => f.name === filterName)
 
   if (filter) {
-    return setFilterValue(getCurrentWorkbook(state), filter, filterValue).always(() => dispatch({
+    const dispatchFilters = () => dispatch({
       type: actionTypes.SET_DASHBOARD_FILTER,
       payload: { name: filterName, value: filterValue },
-    }))
+    })
+    return setFilterValue(getCurrentWorkbook(state), filter, filterValue).then(dispatchFilters, dispatchFilters)
   }
 }
 

--- a/app/js/components/checklist/checklist.jsx
+++ b/app/js/components/checklist/checklist.jsx
@@ -28,7 +28,7 @@ class Checklist extends Component {
     const selectedValues = this.state.values
 
     return (
-      <ul className='checklist'>
+      <ul className={this.props.className || 'checklist'}>
         {allowedValues.map((value) =>
           <li key={value} className='checklist__item'>
             <Checkbox
@@ -48,6 +48,7 @@ Checklist.propTypes = {
   allowedValues: PropTypes.array.isRequired,
   selectedValues: PropTypes.array,
   onChange: PropTypes.func.isRequired,
+  className: React.PropTypes.string,
 }
 
 export default Checklist

--- a/app/js/components/dialogs/trkref_dialog/trkref_dialog.jsx
+++ b/app/js/components/dialogs/trkref_dialog/trkref_dialog.jsx
@@ -3,6 +3,8 @@ import React, { Component, PropTypes } from 'react'
 import Checklist from '../../checklist/checklist'
 import { ClientPortalDialog, ClientPortalDialogSectionTitle } from '../../client_portal_dialog/client_portal_dialog'
 
+import './trkref_dialog.scss'
+
 class TrkrefDialog extends Component {
   constructor (props) {
     super(props)
@@ -33,6 +35,7 @@ class TrkrefDialog extends Component {
       >
         <ClientPortalDialogSectionTitle title='Customise Websites' />
         <Checklist
+          className="trkref-checklist"
           allowedValues={allowedValues}
           selectedValues={selectedValues}
           onChange={this.handleTrkrefsChange}

--- a/app/js/components/dialogs/trkref_dialog/trkref_dialog.scss
+++ b/app/js/components/dialogs/trkref_dialog/trkref_dialog.scss
@@ -1,0 +1,7 @@
+.trkref-checklist {
+  .checklist__item {
+    width: 320px;
+    float:left;
+    display:block;
+  }
+}

--- a/app/js/containers/dashboard_panel_container.js
+++ b/app/js/containers/dashboard_panel_container.js
@@ -10,7 +10,7 @@ class DashboardPanelContainer extends Component {
 
   componentWillUpdate (nextProps) {
     if (nextProps.selectedDashboard !== this.props.selectedDashboard) {
-      this.props.loadTableauDashboard()
+      this.props.loadTableauDashboard(nextProps.availableTrkrefs)
     }
   }
 
@@ -31,10 +31,14 @@ DashboardPanelContainer.propTypes = {
   loadTableauDashboard: PropTypes.func.isRequired,
 }
 
-const mapStateToProps = ({ analyticsApp, router }) => ({
-  leftHandNavVisible: analyticsApp.leftHandNavVisible,
-  selectedDashboard: getSelectedDashboardById(analyticsApp.dashboards, router.params.id),
-})
+const mapStateToProps = ({ analyticsApp, router }) => {
+  let trkrefNames = analyticsApp.profile ? analyticsApp.profile.trkref_names : {}
+  return {
+    leftHandNavVisible: analyticsApp.leftHandNavVisible,
+    selectedDashboard: getSelectedDashboardById(analyticsApp.dashboards, router.params.id),
+    availableTrkrefs: trkrefNames,
+  }
+}
 
 export default connect(
   mapStateToProps,

--- a/app/js/services/cp_analytics_api_client.js
+++ b/app/js/services/cp_analytics_api_client.js
@@ -2,4 +2,3 @@ import { CP_ANALYTICS_API } from '../constants/app_constants'
 import { get, parseJSON } from './auth'
 
 export const getTableauToken = () => get(`${CP_ANALYTICS_API}tableau/token`).then(parseJSON)
-export const getFilter = (filter) => get(`${CP_ANALYTICS_API}filter/${filter}`).then(parseJSON)

--- a/app/js/services/cp_analytics_api_client.js
+++ b/app/js/services/cp_analytics_api_client.js
@@ -2,3 +2,4 @@ import { CP_ANALYTICS_API } from '../constants/app_constants'
 import { get, parseJSON } from './auth'
 
 export const getTableauToken = () => get(`${CP_ANALYTICS_API}tableau/token`).then(parseJSON)
+export const getFilter = (filter) => get(`${CP_ANALYTICS_API}filter/${filter}`).then(parseJSON)

--- a/app/js/services/tableau.js
+++ b/app/js/services/tableau.js
@@ -91,10 +91,7 @@ const getParameters = (workbook) => getWorkbookParameters(workbook).then((tablea
 
 /**
  * Returns formatted tableau filters as application filters
- *
- * This currently just fetches the filters from Tableau and trkrefs from current_user's profile
- * It should also fetch the filters we need from the client_portal-analytics_backend in order to
- * correctly select product names/etc.
+ * It fetches the filters from Tableau and trkrefs from current_user's profile
  */
 const getFilters = (workbook, availableTrkrefs) => getWorkbookFilters(workbook).then((tableauFilters) => {
   let fromTableau = tableauFilters

--- a/tests/unit/app/actions/dashboards.test.js
+++ b/tests/unit/app/actions/dashboards.test.js
@@ -151,8 +151,16 @@ describe('actions', () => {
   })
 
   describe('changeFilter', () => {
-    it('sets a filter value on a dashboard', (done) => {
+    fit('sets a filter value on a dashboard', (done) => {
       const setFilterValueMock = () => Promise.resolve()
+      // The above line doesn't work, because the setFilterValueMock is a *tableau* Promise, not a Promise promise,
+      // see 'Promise Class' here:
+      // https://onlinehelp.tableau.com/current/api/js_api/en-us/JavaScriptAPI/js_api_ref.htm?Highlight=getAppliedValues#ref_head_49
+      // ... not sure how to fix this but the below *doesn't* work:
+      //
+      // const setFilterValueMock = () => {
+      //   return { always: (fun) => fun() }
+      // }
       DashboardRewireAPI.__Rewire__('setFilterValue', setFilterValueMock)
 
       const store = createMockStore({

--- a/tests/unit/app/actions/dashboards.test.js
+++ b/tests/unit/app/actions/dashboards.test.js
@@ -151,16 +151,8 @@ describe('actions', () => {
   })
 
   describe('changeFilter', () => {
-    fit('sets a filter value on a dashboard', (done) => {
+    it('sets a filter value on a dashboard', (done) => {
       const setFilterValueMock = () => Promise.resolve()
-      // The above line doesn't work, because the setFilterValueMock is a *tableau* Promise, not a Promise promise,
-      // see 'Promise Class' here:
-      // https://onlinehelp.tableau.com/current/api/js_api/en-us/JavaScriptAPI/js_api_ref.htm?Highlight=getAppliedValues#ref_head_49
-      // ... not sure how to fix this but the below *doesn't* work:
-      //
-      // const setFilterValueMock = () => {
-      //   return { always: (fun) => fun() }
-      // }
       DashboardRewireAPI.__Rewire__('setFilterValue', setFilterValueMock)
 
       const store = createMockStore({

--- a/tests/unit/app/actions/dashboards.test.js
+++ b/tests/unit/app/actions/dashboards.test.js
@@ -108,6 +108,7 @@ describe('actions', () => {
         expect(store.getActions()).toEqual(expectedActions)
         expect(createTableauAPISpy).toHaveBeenCalledWith({
           userId: 1,
+          availableTrkrefs: undefined,
           token: 'token',
           viewId: 'test/',
           onLoad: jasmine.any(Function),
@@ -140,6 +141,7 @@ describe('actions', () => {
         expect(tableauAPISpy.dispose).toHaveBeenCalled()
         expect(createTableauAPISpy).toHaveBeenCalledWith({
           userId: 1,
+          availableTrkrefs: undefined,
           token: 'token',
           viewId: 'test/',
           onLoad: jasmine.any(Function),


### PR DESCRIPTION
The trkrefs filter from Tableau cannot be used to populate the list of trkrefs because it will limit the number of trkrefs to 200 and it will not contain the Retailer name. Instead, we can use the list of trkrefs that are coming back from the /profile request done to client_portal-admin.