### PR TITLE
Fix issue with missing ids

### DIFF
--- a/app/js/services/tableau_gateway_api_client.js
+++ b/app/js/services/tableau_gateway_api_client.js
@@ -2,5 +2,11 @@ import { TABLEAU_GATEWAY_API } from '../constants/app_constants'
 import { get, parseJSON } from './auth'
 
 const arrayToParam = (name, values) => values.map((value) => `${name}[]=${value}`).join('&')
-export const getWorkbooks = (workbookIds) =>
-  get(`${TABLEAU_GATEWAY_API}workbooks?${arrayToParam('ids', workbookIds)}`).then(parseJSON)
+export const getWorkbooks = (workbookIds) => {
+  let idsChain = 'ids[]='
+
+  if (workbookIds.length > 0) {
+    idsChain = arrayToParam('ids', workbookIds)
+  }
+  return get(`${TABLEAU_GATEWAY_API}workbooks?${idsChain}`).then(parseJSON)
+}


### PR DESCRIPTION
**Previous behaviour:**
If there are no workbooks, we do a call to TableauApiGateway without "ids[]" params. It caused 500 because of missing required param.

**New behaviour**
If there are no workbooks, we do a call with "ids[]=" (empty value) param and it doesn't blow up.