### PR TITLE
Update pact contract for client-portal-admin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine as dev
+FROM node:6.14.4-alpine as dev
 
 WORKDIR /app/
 
@@ -9,7 +9,7 @@ RUN apk update \
         curl \
         openssh-client \
         fontconfig \
-        chromium \ 
+        chromium \
         ruby \
         ruby-dev \
         ruby-irb \

--- a/tests/pact/setup/api_client_portal-admin/setup.js
+++ b/tests/pact/setup/api_client_portal-admin/setup.js
@@ -28,7 +28,7 @@ const setup = (mockService) => {
         login_state: like('enabled'),
         last_login: like('2016-09-14T14:14:30.842+01:00'),
         created_at: like('2016-08-03T14:18:32.213+01:00'),
-        updated_at: null,
+        updated_at: like('2016-08-03T14:18:32.213+01:00'),
         registered_at: null,
         user_type_id: like('11111111-1111-1111-1111-111111111111'),
         user_type: {


### PR DESCRIPTION
- we introducted same timestamp mechanism in client-portal-admin as standard rails application have. Means, when user is created, both created_at and updated_at columns are populated. This pact contract expected updated_at field to be empty, but newly it will be always populated.