### PR TITLE
Pin awscli version for python2.7 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ COPY package.json yarn.lock deploy.sh Gemfile Gemfile.lock ./
 RUN npm install bower -g && \
     npm install grunt -g
 
-RUN pip install awscli --upgrade
+RUN pip install awscli==1.19.112
 
 RUN echo '{ "allow_root": true }' > /root/.bowerrc


### PR DESCRIPTION
If we want to use latest awscli we need to upgrade base image (node) in
order to use python3. Pinning awscli to a python2.7 compatible version
is a temp workaround.